### PR TITLE
fix: 날짜  선택 후 즉시 상태 변경

### DIFF
--- a/src/routes/dashboard/mediaChannel/index.tsx
+++ b/src/routes/dashboard/mediaChannel/index.tsx
@@ -14,9 +14,10 @@ const MediaChannel = () => {
     ['mediaChannelData', date],
     () => fetchMediaChannelData(date).then((res) => res.data),
     {
-      staleTime: 1000 * 6 * 5,
+      staleTime: 1000,
     }
   );
+  console.log({ isLoading });
 
   return (
     <main>


### PR DESCRIPTION
## 수정 사항
- 두 번 눌러야 적용되었던 그래프 계산 오류 해결
- `fetchMediaChannelData` 함수를 hook에서 util로 변경
- trendData 함수와 비슷하게 수정

https://user-images.githubusercontent.com/79626675/170236011-669a4ed5-7552-4e9f-ad23-56dd3d143b4a.mov


 