### PR TITLE
style: 로딩 상태에 따라 아이템 요소에 opacity transition 부여하도록 수정

### DIFF
--- a/src/routes/dashboard/integratedAd/index.tsx
+++ b/src/routes/dashboard/integratedAd/index.tsx
@@ -13,7 +13,7 @@ import { useRecoilValue } from 'recoil';
 const IntegratedAd = () => {
   const date = useRecoilValue<IPeriod>(periodState);
 
-  const { data } = useQuery(['trendData', date], () => getTrendData(date).then((res) => res.data), {
+  const { data, isLoading } = useQuery(['trendData', date], () => getTrendData(date).then((res) => res.data), {
     staleTime: 1000 * 6 * 5,
   });
   const trendData: ITrendDataGrid = calTrendData(data);
@@ -22,7 +22,7 @@ const IntegratedAd = () => {
       <p className={styles.title}>통합 광고 현황</p>
       <WhiteSection>
         <div className={styles.integratedAdWrapper}>
-          <TrendDataStatus trendData={trendData} />
+          <TrendDataStatus trendData={trendData} isLoading={isLoading} />
           {/* <TrendDataStatus /> */}
         </div>
       </WhiteSection>

--- a/src/routes/dashboard/integratedAd/trendData/index.tsx
+++ b/src/routes/dashboard/integratedAd/trendData/index.tsx
@@ -4,17 +4,18 @@ import { ITrendDataGrid } from 'types/trendData';
 
 interface Props {
   trendData: ITrendDataGrid;
+  isLoading: boolean;
 }
 
-const TrendDataStatus = ({ trendData }: Props) => {
+const TrendDataStatus = ({ trendData, isLoading }: Props) => {
   return (
     <div className={cs.mainGrid}>
-      <TrendDataItem title='ROAS' data={trendData.roas} type='%' />
-      <TrendDataItem title='광고비' data={trendData.cost} type='원' />
-      <TrendDataItem title='노출수' data={trendData.imp} type='회' />
-      <TrendDataItem title='클릭수' data={trendData.click} type='회' />
-      <TrendDataItem title='전환수' data={trendData.conversion} type='회' />
-      <TrendDataItem title='매출' data={trendData.convValue} type='원' />
+      <TrendDataItem title='ROAS' data={trendData.roas} type='%' isLoading={isLoading} />
+      <TrendDataItem title='광고비' data={trendData.cost} type='원' isLoading={isLoading} />
+      <TrendDataItem title='노출수' data={trendData.imp} type='회' isLoading={isLoading} />
+      <TrendDataItem title='클릭수' data={trendData.click} type='회' isLoading={isLoading} />
+      <TrendDataItem title='전환수' data={trendData.conversion} type='회' isLoading={isLoading} />
+      <TrendDataItem title='매출' data={trendData.convValue} type='원' isLoading={isLoading} />
     </div>
   );
 };

--- a/src/routes/dashboard/integratedAd/trendData/trendDataItem/index.tsx
+++ b/src/routes/dashboard/integratedAd/trendData/trendDataItem/index.tsx
@@ -1,3 +1,5 @@
+import cx from 'classnames';
+
 import cs from './trandDataItem.module.scss';
 import { ITrendDataGridItem } from 'types/trendData';
 
@@ -5,13 +7,14 @@ interface Props {
   title: string;
   data: ITrendDataGridItem;
   type: '원' | '%' | '회';
+  isLoading: boolean;
 }
 
-const TrendDataItem = ({ title, data, type }: Props) => {
+const TrendDataItem = ({ title, data, type, isLoading }: Props) => {
   return (
     <div className={cs.gridItem}>
       <title>{title}</title>
-      <div className={cs.itemValue}>
+      <div className={cx(cs.itemOff, !isLoading && cs.itemValue)}>
         <strong>{` ${data.value} ${type}`}</strong>
         <div>
           <div className={data.compare ? cs.triangleUp : cs.triangleDown} />

--- a/src/routes/dashboard/integratedAd/trendData/trendDataItem/trandDataItem.module.scss
+++ b/src/routes/dashboard/integratedAd/trendData/trendDataItem/trandDataItem.module.scss
@@ -8,9 +8,9 @@
   width: 100%;
   height: 100%;
   padding: 1.8rem 1.8rem 1.8rem 4rem;
-  border-radius: 10px;
-  border: 0.1rem solid colors.$GREY_50;
   background-color: colors.$WHITE;
+  border: 0.1rem solid colors.$GREY_50;
+  border-radius: 10px;
 
   > title {
     display: block;
@@ -18,11 +18,16 @@
     color: colors.$GREY_300;
   }
 
-  .itemValue {
+  .itemOff {
+    opacity: 0;
+  }
 
+  .itemValue {
     display: flex;
     justify-content: space-between;
     font-weight: bold;
+    opacity: 1;
+    transition: opacity 0.7s;
 
     > strong {
       font-size: 1.6rem;
@@ -37,16 +42,16 @@
         display: inline-block;
         width: 0.9rem;
         height: 0.9rem;
-        background: colors.$TRIANGLE_UP;
         clip-path: polygon(0% 100%, 50% 0%, 100% 100%);
+        background: colors.$TRIANGLE_UP;
       }
 
       .triangleDown {
         display: inline-block;
         width: 0.9rem;
         height: 0.9rem;
+        clip-path: polygon(50% 100%, 0% 0%, 100% 0%);
         background: colors.$TRIANGLE_DOWN;
-        clip-path: polygon(50% 100% , 0% 0%, 100% 0%);
       }
     }
   }


### PR DESCRIPTION
# 간단한 Opacity Transition 부여

통합 광고 현황 그리드 뷰 부분에서 데이터가 랜더링 될 때, 부드럽게 그려지도록 간단한 opacity 변화 효과를 부여하였습니다.

https://user-images.githubusercontent.com/64524916/170260509-31bd749d-08dd-4b37-8c04-606e7baa9bb3.mov


